### PR TITLE
moved leaflet map state and handlers to a custom hook

### DIFF
--- a/carceral-groups-website/src/App.tsx
+++ b/carceral-groups-website/src/App.tsx
@@ -1,12 +1,9 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
-import { useEffect, useState } from 'react';
 import './App.css';
 import LeafletMap from './components/LeafletMap/LeafletMap';
 import MenuDrawer from './components/MaterialUI/MenuDrawer';
 import { createTheme, ThemeProvider } from '@mui/material';
 import DetailsDrawer from './components/MaterialUI/DetailsDrawer';
-import MapPoint from './models/MapPoint';
-import { getAllMapPoints, getFilterOptions, getUniqueGeoJsonPreppedPoints } from './api/services/MapPointsService';
+import useLeafletMap from './hooks/useLeafletMap';
 
 const darkTheme = createTheme({
   palette: {
@@ -15,60 +12,19 @@ const darkTheme = createTheme({
 });
 
 function App() {
-  const [selectedMarker, setSelectedMarker] = useState<MapPoint[]>()
-  const [dataGeoJson, setDataGeoJson] = useState<any[]>([])
-  const [treeData, setTreeData] = useState<{label: string, checked:boolean, children: any[]}>({ label: 'All', checked: true, children: [] });
-  const [documents, setDocuments] = useState<MapPoint[]>([])
-
-  const handleCheckboxChange = (updatedTreeData: { label: string, checked: boolean, children: any[] }) => {
-    console.log('Updated Tree Data:', updatedTreeData)
-    setTreeData(updatedTreeData)
-    // get all options
-    let queue = [updatedTreeData]
-    const allOptions: any[] = []
-
-    while (queue.length > 0) {
-      const current = queue.shift()
-      allOptions.push(current)
-      if (current && current.children.length > 0)
-        queue = queue.concat(current.children)
-    }
-    console.log(allOptions)
-
-    // update geojson show on map
-    const newGeoJson = dataGeoJson.map((feature) => {
-      const show_on_map = allOptions.find((option) => option?.label === feature.properties.group)?.checked
-      return {
-        ...feature,
-        properties: {
-          ...feature.properties,
-          show_on_map
-        }
-      }
-    })
-    setDataGeoJson(newGeoJson)
-  }
-
-  const handleOnMarkerClick = (latlng: string | undefined) => {
-    console.log(`Map was clicked at ${latlng}}!`)
-    const filtered = documents.filter((doc) => doc.latlngStr === latlng)
-    setSelectedMarker(filtered)
-  }
-
-  useEffect(() => {
-    const documents = getAllMapPoints();
-    const uniqueGeoJsonPreppedData = getUniqueGeoJsonPreppedPoints();
-    const filterOptions = getFilterOptions()
-    setDataGeoJson(uniqueGeoJsonPreppedData);
-    setTreeData(filterOptions);
-    setDocuments(documents);
-  }, [setDocuments, setTreeData, setDataGeoJson])
+  const {
+        selectedMarker,
+        dataGeoJson,
+        treeData,
+        handleCheckboxChange,
+        handleOnMarkerClick
+  } = useLeafletMap()
 
   return (
-    <ThemeProvider theme={darkTheme}>
+    <ThemeProvider theme={darkTheme}>  
       <MenuDrawer options={treeData} onOptionsChange={handleCheckboxChange} />
       <div className="App">
-          <LeafletMap
+          <LeafletMap 
             label='My Leaflet Map'
             tool={'none'}
             geojson={dataGeoJson}

--- a/carceral-groups-website/src/hooks/useLeafletMap.ts
+++ b/carceral-groups-website/src/hooks/useLeafletMap.ts
@@ -1,0 +1,66 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { useEffect, useState } from "react";
+import MapPoint from "../models/MapPoint";
+import { getAllMapPoints, getFilterOptions, getUniqueGeoJsonPreppedPoints } from "../api/services/MapPointsService";
+
+const useLeafletMap = () => {
+    const [selectedMarker, setSelectedMarker] = useState<MapPoint[]>()
+    const [dataGeoJson, setDataGeoJson] = useState<any[]>([])
+    const [treeData, setTreeData] = useState<{label: string, checked:boolean, children: any[]}>({ label: 'All', checked: true, children: [] });
+    const [documents, setDocuments] = useState<MapPoint[]>([])
+
+    const handleCheckboxChange = (updatedTreeData: { label: string, checked: boolean, children: any[] }) => {
+        console.log('Updated Tree Data:', updatedTreeData)
+        setTreeData(updatedTreeData)
+        // get all options
+        let queue = [updatedTreeData]
+        const allOptions: any[] = []
+    
+        while (queue.length > 0) {
+          const current = queue.shift()
+          allOptions.push(current)
+          if (current && current.children.length > 0)
+            queue = queue.concat(current.children)
+        }
+        console.log(allOptions)
+    
+        // update geojson show on map
+        const newGeoJson = dataGeoJson.map((feature) => {
+          const show_on_map = allOptions.find((option) => option?.label === feature.properties.group)?.checked
+          return {
+            ...feature,
+            properties: {
+              ...feature.properties,
+              show_on_map
+            }
+          }
+        })
+        setDataGeoJson(newGeoJson)
+      }
+
+    const handleOnMarkerClick = (latlng: string | undefined) => {
+        console.log(`Map was clicked at ${latlng}}!`)
+        const filtered = documents.filter((doc) => doc.latlngStr === latlng)
+        setSelectedMarker(filtered)
+    }
+
+    useEffect(() => {
+        const documents = getAllMapPoints();
+        const uniqueGeoJsonPreppedData = getUniqueGeoJsonPreppedPoints();
+        const filterOptions = getFilterOptions()
+        setDataGeoJson(uniqueGeoJsonPreppedData);
+        setTreeData(filterOptions);
+        setDocuments(documents);
+      }, [setDocuments, setTreeData, setDataGeoJson])
+
+    return {
+        selectedMarker,
+        dataGeoJson,
+        treeData,
+        documents,
+        handleCheckboxChange,
+        handleOnMarkerClick
+    }
+}
+
+export default useLeafletMap;


### PR DESCRIPTION
Moved the leaflet map related state and handlers to a custom hook. This cleans up App.tsx, but state and handlers are still being passed down like before. I'll likely end up using a custom context so that the state and handlers don't get passed down, but wanted to think that through a bit more. This is the first step towards that.