### PR TITLE
Celucate/add document controller

### DIFF
--- a/carceral-groups-api/Controllers/DocumentController.cs
+++ b/carceral-groups-api/Controllers/DocumentController.cs
@@ -1,0 +1,126 @@
+using System.Net;
+using CarceralGroupsAPI;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+
+namespace carceral_groups_api.Controllers
+{
+    [ApiController]
+    [Route("[controller]")]
+    public class DocumentController(AppDbContext dbContext) : ControllerBase
+    {
+        private readonly AppDbContext _dbContext = dbContext;
+
+        [HttpGet("{id}")]
+        public async Task<IActionResult?> Get(int id)
+        {
+            try{
+                DocumentCRUDModel? document = await _dbContext.Documents.AsNoTracking()
+                    .Where(m => m.DocumentId == id)
+                    .Select(m => new DocumentCRUDModel(m))
+                    .FirstOrDefaultAsync();
+
+                if(document == null)
+                    return NotFound(document);
+                
+                return Ok(document);
+            }
+            catch(Exception){
+                return StatusCode((int)HttpStatusCode.InternalServerError, Messages.DatabaseReadError);
+            }
+        }
+
+        [HttpPost]
+        public async Task<IActionResult?> Post([FromBody] DocumentCRUDModel request)
+        {
+            try{
+                var documentExists = _dbContext.Documents.Any(m => m.DocumentTitle == request.DocumentTitle);
+                if(documentExists)
+                    return StatusCode((int)HttpStatusCode.Conflict, Messages.ResourceAlreadyExists);
+            }
+            catch(Exception){
+                return StatusCode((int)HttpStatusCode.InternalServerError, Messages.DatabaseReadError);
+            }
+
+            try{
+                var document = new Document{
+                    DocumentTitle = request.DocumentTitle,
+                    FileTitle = request.FileTitle,
+                    URI = request.URI,
+                    DocumentTypeId = request.DocumentTypeId,
+                    CategoryId = request.CategoryId,
+                    InstitutionId = request.InstitutionId,
+                    GeographicLocationId = request.GeographicLocationId
+                };
+
+                await _dbContext.Documents.AddAsync(document);
+                await _dbContext.SaveChangesAsync();
+                return Ok(new DocumentCreateResponse(document));
+            }
+            catch (Exception)
+            {
+                return StatusCode((int)HttpStatusCode.InternalServerError, Messages.DatabaseSaveError);
+            }
+        }
+
+        [HttpPut("{id}")]
+        public async Task<IActionResult> Put(int id, [FromBody] DocumentCRUDModel request)
+        {
+            Document? document = null;
+
+            try{
+                document = await _dbContext.Documents.FirstOrDefaultAsync(m => m.DocumentId == id);
+                if(document == null)
+                    return NotFound();
+
+                var documentExists = _dbContext.Documents.Any(m => m.DocumentTitle == request.DocumentTitle && m.DocumentId != id);
+                if(documentExists)
+                    return StatusCode((int)HttpStatusCode.Conflict, Messages.ResourceAlreadyExists);
+            }
+            catch(Exception){
+                return StatusCode((int)HttpStatusCode.InternalServerError, Messages.DatabaseReadError);
+            }
+
+            try{
+                document.DocumentTitle = request.DocumentTitle;
+                document.FileTitle = request.FileTitle;
+                document.URI = request.URI;
+                document.DocumentTypeId = request.DocumentTypeId;
+                document.CategoryId = request.CategoryId;
+                document.InstitutionId = request.InstitutionId;
+                document.GeographicLocationId = request.GeographicLocationId;
+
+                _dbContext.Documents.Update(document);
+                await _dbContext.SaveChangesAsync();
+                return Ok(new DocumentCRUDModel(document));
+            }
+            catch(Exception){
+                return StatusCode((int)HttpStatusCode.InternalServerError, Messages.DatabaseSaveError);
+            }
+        }
+
+        [HttpDelete("{id}")]
+            public async Task<IActionResult> Delete(int id)
+        {
+            Document? document = null;
+
+            try{
+                document = await _dbContext.Documents.FirstOrDefaultAsync(m => m.DocumentId == id);
+                if(document == null)
+                    return NotFound();
+            }
+            catch(Exception){
+                return StatusCode((int)HttpStatusCode.InternalServerError, Messages.DatabaseReadError);
+            }
+
+            try{
+                _dbContext.Documents.Remove(document);
+                await _dbContext.SaveChangesAsync();
+                return Ok();
+            }
+            catch(Exception){
+                return StatusCode((int)HttpStatusCode.InternalServerError, Messages.DatabaseSaveError);
+            }
+        }
+    }
+}

--- a/carceral-groups-api/Controllers/DocumentTypesController.cs
+++ b/carceral-groups-api/Controllers/DocumentTypesController.cs
@@ -20,7 +20,7 @@ namespace carceral_groups_api.Controllers
         {
             var documentTypes = await _dbContext.Documents
                 .Where(m => m.GeographicLocationId == geographicLocationId)
-                .Select(m => m.DocumentType.Name)
+                .Select(m => m.DocumentType != null ? m.DocumentType.Name : string.Empty)
                 .Distinct()
                 .ToArrayAsync();
 

--- a/carceral-groups-api/Controllers/FiltersController.cs
+++ b/carceral-groups-api/Controllers/FiltersController.cs
@@ -28,7 +28,7 @@ namespace carceral_groups_api.Controllers
                     Category = category.Name,
                     Institutions = await _dbContext.Documents
                         .Where(m => m.CategoryId == category.CategoryId)
-                        .Select(m => m.Institution.Name)
+                        .Select(m => m.Institution != null ? m.Institution.Name : string.Empty)
                         .Distinct()
                         .ToListAsync()
                 });

--- a/carceral-groups-api/Controllers/GeographicLocationsController.cs
+++ b/carceral-groups-api/Controllers/GeographicLocationsController.cs
@@ -16,7 +16,7 @@ namespace carceral_groups_api.Controllers
         }
 
         [HttpPost]
-        public async Task<IEnumerable<GeographicLocation>> Post(GeographicFilterRequest request)
+        public async Task<IEnumerable<GeographicLocation?>> Post(GeographicFilterRequest request)
         {
             var query = _dbContext.Documents.AsQueryable();
 

--- a/carceral-groups-api/EF/Models/Documents.cs
+++ b/carceral-groups-api/EF/Models/Documents.cs
@@ -16,16 +16,16 @@ namespace CarceralGroupsAPI
         [StringLength(maximumLength: 512)]
         public required string    URI { get; set; }
 
-        public int DocumentTypeId { get; set; }
-        public required DocumentType DocumentType { get; set; }
+        public required int DocumentTypeId { get; set; }
+        public DocumentType? DocumentType { get; set; }
 
-        public int CategoryId { get; set; }
-        public required Category Category { get; set; }
+        public required int CategoryId { get; set; }
+        public Category? Category { get; set; }
         
-        public int InstitutionId { get; set; }
-        public required Institution Institution { get; set; }
+        public required int InstitutionId { get; set; }
+        public Institution? Institution { get; set; }
 
-        public int GeographicLocationId { get; set; }
-        public required GeographicLocation GeographicLocation { get; set; }
+        public required int GeographicLocationId { get; set; }
+        public GeographicLocation? GeographicLocation { get; set; }
     }
 }

--- a/carceral-groups-api/EF/Models/Documents.cs
+++ b/carceral-groups-api/EF/Models/Documents.cs
@@ -11,7 +11,7 @@ namespace CarceralGroupsAPI
         public required string DocumentTitle { get; set; }
 
         [StringLength(maximumLength: 256)]
-        public required string FileTitle {get; set; }
+        public string? FileTitle {get; set; }
 
         [StringLength(maximumLength: 512)]
         public required string    URI { get; set; }

--- a/carceral-groups-api/Migrations/20240530071215_MakeDocumentFileTitleNullable.Designer.cs
+++ b/carceral-groups-api/Migrations/20240530071215_MakeDocumentFileTitleNullable.Designer.cs
@@ -3,6 +3,7 @@ using CarceralGroupsAPI;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -10,9 +11,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace carceral_groups_api.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20240530071215_MakeDocumentFileTitleNullable")]
+    partial class MakeDocumentFileTitleNullable
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/carceral-groups-api/Migrations/20240530071215_MakeDocumentFileTitleNullable.cs
+++ b/carceral-groups-api/Migrations/20240530071215_MakeDocumentFileTitleNullable.cs
@@ -1,0 +1,40 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace carceral_groups_api.Migrations
+{
+    /// <inheritdoc />
+    public partial class MakeDocumentFileTitleNullable : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "FileTitle",
+                table: "Documents",
+                type: "nvarchar(256)",
+                maxLength: 256,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(256)",
+                oldMaxLength: 256);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "FileTitle",
+                table: "Documents",
+                type: "nvarchar(256)",
+                maxLength: 256,
+                nullable: false,
+                defaultValue: "",
+                oldClrType: typeof(string),
+                oldType: "nvarchar(256)",
+                oldMaxLength: 256,
+                oldNullable: true);
+        }
+    }
+}

--- a/carceral-groups-api/Models/DocumentCRUDModel.cs
+++ b/carceral-groups-api/Models/DocumentCRUDModel.cs
@@ -23,7 +23,7 @@ namespace CarceralGroupsAPI
         public required string DocumentTitle { get; set; }
 
         [StringLength(maximumLength: 256)]
-        public required string FileTitle {get; set; }
+        public string? FileTitle {get; set; }
 
         [StringLength(maximumLength: 512)]
         public required string URI { get; set; }

--- a/carceral-groups-api/Models/DocumentCRUDModel.cs
+++ b/carceral-groups-api/Models/DocumentCRUDModel.cs
@@ -1,0 +1,39 @@
+using System.ComponentModel.DataAnnotations;
+using System.Diagnostics.CodeAnalysis;
+
+namespace CarceralGroupsAPI
+{
+    public class DocumentCRUDModel
+    {
+        public DocumentCRUDModel(){}
+        
+        [SetsRequiredMembers]
+        public DocumentCRUDModel(Document document)
+        {
+            DocumentTitle = document.DocumentTitle;
+            FileTitle = document.FileTitle;
+            URI = document.URI;
+            DocumentTypeId = document.DocumentTypeId;
+            CategoryId = document.CategoryId;
+            InstitutionId = document.InstitutionId;
+            GeographicLocationId = document.GeographicLocationId;
+        }
+
+        [StringLength(maximumLength: 256)]
+        public required string DocumentTitle { get; set; }
+
+        [StringLength(maximumLength: 256)]
+        public required string FileTitle {get; set; }
+
+        [StringLength(maximumLength: 512)]
+        public required string URI { get; set; }
+
+        public required int DocumentTypeId { get; set; }
+
+        public required int CategoryId { get; set; }
+        
+        public required int InstitutionId { get; set; }
+
+        public required int GeographicLocationId { get; set; }
+    }
+}

--- a/carceral-groups-api/Models/DocumentCreateResponse.cs
+++ b/carceral-groups-api/Models/DocumentCreateResponse.cs
@@ -1,0 +1,14 @@
+using System.Diagnostics.CodeAnalysis;
+
+namespace CarceralGroupsAPI
+{
+    public class DocumentCreateResponse: DocumentCRUDModel
+    {
+        [SetsRequiredMembers]
+        public DocumentCreateResponse(Document document): base(document)
+        {
+            DocumentId = document.DocumentId;
+        }
+        public required int DocumentId { get; set; }
+    }
+}


### PR DESCRIPTION
- Swaps required attribute on Document foreign key properties to the integer property instead of the navigation property.
- Makes Document's FileTitle field nullable (Keeping as this may come in handy for data migration). Will drop column afterwards.
- Adds CRUD endpoints for a Document