### PR TITLE
44: Different Color Markers

### DIFF
--- a/carceral-groups-api/Controllers/FiltersController.cs
+++ b/carceral-groups-api/Controllers/FiltersController.cs
@@ -38,7 +38,35 @@ namespace carceral_groups_api.Controllers
                 });
             }
 
+            // TODO: Remove when added as column to DB
+            response.Filters = AddColorToCategories(response.Filters);
+
             return response;
         }
+
+
+        // TODO: Remove when added as column to DB
+        private List<FiltersResponseFilter> AddColorToCategories(List<FiltersResponseFilter> categories){
+            var random = new Random();
+            foreach(var category in categories){
+                category.Color = Colors[random.Next(Colors.Count)];
+            }
+            return categories;
+        }
+
+        // TODO: Remove when added as column to DB
+        private List<string> Colors = new List<string>{
+            "red",
+            "blue",
+            "green",
+            "purple",
+            "orange",
+            "darkred",
+            "lightred",
+            "beige",
+            "pink",
+            "lightblue",
+            "lightgreen",
+        };
     }
 }

--- a/carceral-groups-api/Controllers/FiltersController.cs
+++ b/carceral-groups-api/Controllers/FiltersController.cs
@@ -27,6 +27,7 @@ namespace carceral_groups_api.Controllers
                 response.Filters.Add(new FiltersResponseFilter{
                     Category = category.Name,
                     CategoryId = category.CategoryId,
+                    Color = category.Color,
                     Institutions = await _dbContext.Documents
                         .Where(m => m.CategoryId == category.CategoryId)
                         .Select(m => m.Institution != null ? 
@@ -38,35 +39,7 @@ namespace carceral_groups_api.Controllers
                 });
             }
 
-            // TODO: Remove when added as column to DB
-            response.Filters = AddColorToCategories(response.Filters);
-
             return response;
         }
-
-
-        // TODO: Remove when added as column to DB
-        private List<FiltersResponseFilter> AddColorToCategories(List<FiltersResponseFilter> categories){
-            var random = new Random();
-            foreach(var category in categories){
-                category.Color = Colors[random.Next(Colors.Count)];
-            }
-            return categories;
-        }
-
-        // TODO: Remove when added as column to DB
-        private List<string> Colors = new List<string>{
-            "red",
-            "blue",
-            "green",
-            "purple",
-            "orange",
-            "darkred",
-            "lightred",
-            "beige",
-            "pink",
-            "lightblue",
-            "lightgreen",
-        };
     }
 }

--- a/carceral-groups-api/Models/FiltersResponse.cs
+++ b/carceral-groups-api/Models/FiltersResponse.cs
@@ -10,6 +10,8 @@ namespace CarceralGroupsAPI
         public required int CategoryId { get; set; }
         public required string Category { get; set; }
 
+        public string? Color { get; set; }
+
         public List<FiltersResponseFilterInstitution>? Institutions { get; set; }
     }
 

--- a/carceral-groups-website/src/api/services/MapPointsService.ts
+++ b/carceral-groups-website/src/api/services/MapPointsService.ts
@@ -116,40 +116,6 @@ export const getFilterOptions = async () => {
     }
 }
 
-const locationColors = (locations: GeographicLocation[]) => {
-    const locationAddedColors = addColorProperty(locations)
-    return locationAddedColors;
-
-}
-
-const addColorProperty = (model: any[]) => {
-    const colors = [
-        'red',
-        'blue',
-        'green',
-        'purple',
-        'orange',
-        'darkred',
-        'lightred',
-        'beige',
-        'darkblue',
-        'darkgreen',
-        'cadetblue',
-        'darkpurple',
-        'white',
-        'pink',
-        'lightblue',
-        'lightgreen',
-        'gray',
-        'black',
-        'lightgray'
-    ]
-    model.forEach((cur, index) => {
-        cur.color = colors[index % colors.length]
-    })
-    return model;
-}
-
 /**
  * Filters and transforms geographic data points based on selected filters.
  * 
@@ -178,8 +144,7 @@ export const getGeographicLocations = async (selectedGeographicLocationFilters: 
                 }
             }
         )
-        let geographicLocations = await response.json() as GeographicLocation[];
-        geographicLocations = locationColors(geographicLocations) // determine if we want to add colors as part of the model or not
+        const geographicLocations = await response.json() as GeographicLocation[];
         console.log("TODO_getGeographicLocation_response", geographicLocations)
         return geographicLocations
 

--- a/carceral-groups-website/src/api/services/MapPointsService.ts
+++ b/carceral-groups-website/src/api/services/MapPointsService.ts
@@ -108,18 +108,12 @@ export const getFilterOptions = async () => {
     try {
         const resJson = await fetchWithLocalCache(`${backend_api_url}/filters`, 'filters')
         console.log("TODO_getFilterOptions_response", resJson)
-        let filters = resJson.filters as FiltersResponseFilter[];
-        filters = filterColors(filters) // determine if we want to add colors as part of the model or not
+        const filters = resJson.filters as FiltersResponseFilter[];
         return filters;
     } catch (error) {
         console.error('Error fetching or processing filters:', error);
         return [];
     }
-}
-
-const filterColors = (filters: FiltersResponseFilter[]) => {
-    const filterAddedColors = addColorProperty(filters)
-    return filterAddedColors;
 }
 
 const locationColors = (locations: GeographicLocation[]) => {

--- a/carceral-groups-website/src/api/services/MapPointsService.ts
+++ b/carceral-groups-website/src/api/services/MapPointsService.ts
@@ -118,6 +118,17 @@ export const getFilterOptions = async () => {
 }
 
 const filterColors = (filters: FiltersResponseFilter[]) => {
+    const filterAddedColors = addColorProperty(filters)
+    return filterAddedColors;
+}
+
+const locationColors = (locations: GeographicLocation[]) => {
+    const locationAddedColors = addColorProperty(locations)
+    return locationAddedColors;
+
+}
+
+const addColorProperty = (model: any[]) => {
     const colors = [
         'red',
         'blue',
@@ -139,11 +150,10 @@ const filterColors = (filters: FiltersResponseFilter[]) => {
         'black',
         'lightgray'
     ]
-    const filterAddedColors = filters.map((filter, index) => {
-        filter.color = colors[index % colors.length]
-        return filter;
+    model.forEach((cur, index) => {
+        cur.color = colors[index % colors.length]
     })
-    return filterAddedColors;
+    return model;
 }
 
 /**
@@ -174,7 +184,8 @@ export const getGeographicLocations = async (selectedGeographicLocationFilters: 
                 }
             }
         )
-        const geographicLocations = await response.json() as GeographicLocation[];
+        let geographicLocations = await response.json() as GeographicLocation[];
+        geographicLocations = locationColors(geographicLocations) // determine if we want to add colors as part of the model or not
         console.log("TODO_getGeographicLocation_response", geographicLocations)
         return geographicLocations
 

--- a/carceral-groups-website/src/api/services/MapPointsService.ts
+++ b/carceral-groups-website/src/api/services/MapPointsService.ts
@@ -108,12 +108,42 @@ export const getFilterOptions = async () => {
     try {
         const resJson = await fetchWithLocalCache(`${backend_api_url}/filters`, 'filters')
         console.log("TODO_getFilterOptions_response", resJson)
-        const filters = resJson.filters as FiltersResponseFilter[];
+        let filters = resJson.filters as FiltersResponseFilter[];
+        filters = filterColors(filters) // determine if we want to add colors as part of the model or not
         return filters;
     } catch (error) {
         console.error('Error fetching or processing filters:', error);
         return [];
     }
+}
+
+const filterColors = (filters: FiltersResponseFilter[]) => {
+    const colors = [
+        'red',
+        'blue',
+        'green',
+        'purple',
+        'orange',
+        'darkred',
+        'lightred',
+        'beige',
+        'darkblue',
+        'darkgreen',
+        'cadetblue',
+        'darkpurple',
+        'white',
+        'pink',
+        'lightblue',
+        'lightgreen',
+        'gray',
+        'black',
+        'lightgray'
+    ]
+    const filterAddedColors = filters.map((filter, index) => {
+        filter.color = colors[index % colors.length]
+        return filter;
+    })
+    return filterAddedColors;
 }
 
 /**

--- a/carceral-groups-website/src/components/LeafletMap/LeafletMap.tsx
+++ b/carceral-groups-website/src/components/LeafletMap/LeafletMap.tsx
@@ -13,16 +13,6 @@ type LeafLetHelper = {
   groups: LeafLetGroup[];
 };
 
-const RedMarkerIcon = L.icon({
-  // iconUrl: '/assets/red_pin.png',
-  // TODO: figure out how to get the assets URL from the environment in squarespace.
-  iconUrl: "https://vialekhnstore.z1.web.core.windows.net/assets/red_pin.png",
-  iconSize: [25, 41],
-  iconAnchor: [12, 41],
-  popupAnchor: [1, -34],
-  shadowSize: [41, 41]
-});
-
 type LeafletMapProps = {
   geojson?: any;
   onMarkerClick: (geographicLocationId: string) => void;
@@ -65,8 +55,9 @@ const LeafletMap: React.FC<LeafletMapProps> = ({ geojson, onMarkerClick }) => {
     if (leafletHelperRef.current && geojson) {
       // Add GeoJSON layer
       const geoJSON = L.geoJSON(geojson, {
-        pointToLayer: (_geoJsonPoint, latlng) => {
-          return L.marker(latlng, { icon: RedMarkerIcon })
+        pointToLayer: (geoJsonPoint, latlng) => {
+          const style = {color: geoJsonPoint.properties.color, radius: 8, fillColor: geoJsonPoint.properties.color, fillOpacity: 0.8}
+          return L.circleMarker(latlng, style)
         },
         onEachFeature: (feature, layer) => {
           if (feature.properties?.popupContent) {

--- a/carceral-groups-website/src/components/MaterialUI/CustomColorCheckbox.tsx
+++ b/carceral-groups-website/src/components/MaterialUI/CustomColorCheckbox.tsx
@@ -1,7 +1,12 @@
+import * as React from 'react';
 import { styled } from '@mui/material/styles';
 import Checkbox, { CheckboxProps } from '@mui/material/Checkbox';
 
-const BpIcon = styled('span')(({ theme }) => ({
+interface CustomIconProps {
+  customColor?: string;
+}
+
+const BpIcon = styled('span')<CustomIconProps>(({ theme, customColor }) => ({
   borderRadius: 3,
   width: 16,
   height: 16,
@@ -9,7 +14,7 @@ const BpIcon = styled('span')(({ theme }) => ({
     theme.palette.mode === 'dark'
       ? '0 0 0 1px rgb(16 22 26 / 40%)'
       : 'inset 0 0 0 1px rgba(16,22,26,.2), inset 0 -1px 0 rgba(16,22,26,.1)',
-  backgroundColor: theme.palette.mode === 'dark' ? '#394b59' : '#f5f8fa',
+  backgroundColor: customColor || (theme.palette.mode === 'dark' ? '#394b59' : '#f5f8fa'),
   backgroundImage:
     theme.palette.mode === 'dark'
       ? 'linear-gradient(180deg,hsla(0,0%,100%,.05),hsla(0,0%,100%,0))'
@@ -19,17 +24,20 @@ const BpIcon = styled('span')(({ theme }) => ({
     outlineOffset: 2,
   },
   'input:hover ~ &': {
-    backgroundColor: theme.palette.mode === 'dark' ? '#30404d' : '#ebf1f5',
+    backgroundColor: customColor || (theme.palette.mode === 'dark' ? '#30404d' : '#ebf1f5'),
   },
   'input:disabled ~ &': {
     boxShadow: 'none',
-    background:
-      theme.palette.mode === 'dark' ? 'rgba(57,75,89,.5)' : 'rgba(206,217,224,.5)',
+    background: customColor
+      ? `${customColor}80`
+      : theme.palette.mode === 'dark'
+      ? 'rgba(57,75,89,.5)'
+      : 'rgba(206,217,224,.5)',
   },
 }));
 
-const BpCheckedIcon = styled(BpIcon)({
-  backgroundColor: '#137cbd',
+const BpCheckedIcon = styled(BpIcon)<CustomIconProps>(({ customColor }) => ({
+  backgroundColor: customColor || '#137cbd',
   backgroundImage: 'linear-gradient(180deg,hsla(0,0%,100%,.1),hsla(0,0%,100%,0))',
   '&::before': {
     display: 'block',
@@ -42,12 +50,16 @@ const BpCheckedIcon = styled(BpIcon)({
     content: '""',
   },
   'input:hover ~ &': {
-    backgroundColor: '#106ba3',
+    backgroundColor: customColor || '#106ba3',
   },
-});
+}));
 
 // Inspired by blueprintjs
-export default function CustomColorCheckbox(props: CheckboxProps) {
+interface CustomColorCheckboxProps extends CheckboxProps {
+  customColor?: string;
+}
+
+const CustomColorCheckbox: React.FC<CustomColorCheckboxProps> = ({ customColor, ...props }) => {
   return (
     <Checkbox
       sx={{
@@ -55,10 +67,12 @@ export default function CustomColorCheckbox(props: CheckboxProps) {
       }}
       disableRipple
       color="default"
-      checkedIcon={<BpCheckedIcon />}
-      icon={<BpIcon />}
+      checkedIcon={<BpCheckedIcon customColor={customColor} />}
+      icon={<BpIcon customColor={customColor} />}
       inputProps={{ 'aria-label': 'Checkbox' }}
       {...props}
     />
   );
-}
+};
+
+export default CustomColorCheckbox;

--- a/carceral-groups-website/src/components/MaterialUI/CustomColorCheckbox.tsx
+++ b/carceral-groups-website/src/components/MaterialUI/CustomColorCheckbox.tsx
@@ -1,0 +1,64 @@
+import { styled } from '@mui/material/styles';
+import Checkbox, { CheckboxProps } from '@mui/material/Checkbox';
+
+const BpIcon = styled('span')(({ theme }) => ({
+  borderRadius: 3,
+  width: 16,
+  height: 16,
+  boxShadow:
+    theme.palette.mode === 'dark'
+      ? '0 0 0 1px rgb(16 22 26 / 40%)'
+      : 'inset 0 0 0 1px rgba(16,22,26,.2), inset 0 -1px 0 rgba(16,22,26,.1)',
+  backgroundColor: theme.palette.mode === 'dark' ? '#394b59' : '#f5f8fa',
+  backgroundImage:
+    theme.palette.mode === 'dark'
+      ? 'linear-gradient(180deg,hsla(0,0%,100%,.05),hsla(0,0%,100%,0))'
+      : 'linear-gradient(180deg,hsla(0,0%,100%,.8),hsla(0,0%,100%,0))',
+  '.Mui-focusVisible &': {
+    outline: '2px auto rgba(19,124,189,.6)',
+    outlineOffset: 2,
+  },
+  'input:hover ~ &': {
+    backgroundColor: theme.palette.mode === 'dark' ? '#30404d' : '#ebf1f5',
+  },
+  'input:disabled ~ &': {
+    boxShadow: 'none',
+    background:
+      theme.palette.mode === 'dark' ? 'rgba(57,75,89,.5)' : 'rgba(206,217,224,.5)',
+  },
+}));
+
+const BpCheckedIcon = styled(BpIcon)({
+  backgroundColor: '#137cbd',
+  backgroundImage: 'linear-gradient(180deg,hsla(0,0%,100%,.1),hsla(0,0%,100%,0))',
+  '&::before': {
+    display: 'block',
+    width: 16,
+    height: 16,
+    backgroundImage:
+      "url(\"data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3E%3Cpath" +
+      " fill-rule='evenodd' clip-rule='evenodd' d='M12 5c-.28 0-.53.11-.71.29L7 9.59l-2.29-2.3a1.003 " +
+      "1.003 0 00-1.42 1.42l3 3c.18.18.43.29.71.29s.53-.11.71-.29l5-5A1.003 1.003 0 0012 5z' fill='%23fff'/%3E%3C/svg%3E\")",
+    content: '""',
+  },
+  'input:hover ~ &': {
+    backgroundColor: '#106ba3',
+  },
+});
+
+// Inspired by blueprintjs
+export default function CustomColorCheckbox(props: CheckboxProps) {
+  return (
+    <Checkbox
+      sx={{
+        '&:hover': { bgcolor: 'transparent' },
+      }}
+      disableRipple
+      color="default"
+      checkedIcon={<BpCheckedIcon />}
+      icon={<BpIcon />}
+      inputProps={{ 'aria-label': 'Checkbox' }}
+      {...props}
+    />
+  );
+}

--- a/carceral-groups-website/src/components/MaterialUI/FilterOptions.tsx
+++ b/carceral-groups-website/src/components/MaterialUI/FilterOptions.tsx
@@ -1,6 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import Box from '@mui/material/Box';
-import Checkbox from '@mui/material/Checkbox';
 import FormControlLabel from '@mui/material/FormControlLabel';
 import { useEffect, useState } from 'react';
 import FiltersResponseFilter from '../../models/FiltersResponseFilter';
@@ -10,6 +9,7 @@ import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 
 
 
+import CustomColorCheckbox from './CustomColorCheckbox';
 
 export interface FilterOptionsProps {
   options: FiltersResponseFilter[]
@@ -23,12 +23,13 @@ type filterOptionModel = {
   checked: boolean,
   indeterminate: boolean,
   geographicLocationFilter?: GeographicLocationFilter,
+  color: string
 }
 
 const transformFiltersToFilterOptions = (filters: FiltersResponseFilter[]): filterOptionModel[] => {
   // add all option
   const newFilterOptions: filterOptionModel[] = []
-  const defaultOption: filterOptionModel = { prefix: '', label: 'All', level: 0, checked: true, indeterminate: false }
+  const defaultOption: filterOptionModel = { prefix: '', label: 'All', level: 0, checked: true, indeterminate: false, color: '#f03' }
   newFilterOptions.push(defaultOption)
 
   // add categories and institutions
@@ -43,14 +44,16 @@ const transformFiltersToFilterOptions = (filters: FiltersResponseFilter[]): filt
           level: 4,
           checked: true,
           indeterminate: false,
+          color: filter.color ? filter.color : '#f03',
           geographicLocationFilter: { Category: filter.category, Institution: curInstitution.institution, CategoryId: filter.categoryId, InstitutionId: curInstitution.institutionId }
         }
       })
       institionOptions.push(...possibleInstitutions)
     }
 
-    return { category: { prefix: ':All', label: filter.category, level: 2, checked: true, indeterminate: false }, institutions: institionOptions }
+    return { category: { prefix: ':All', label: filter.category, level: 2, checked: true, indeterminate: false, color: filter.color ? filter.color : '#f03' }, institutions: institionOptions }
   })
+
 
   categoryOptions.forEach((categoryOption) => {
     // add category as a filter option
@@ -144,10 +147,10 @@ export default function FilterOptions({ options, onOptionsChange }: FilterOption
         <FormControlLabel
           label={option.label}
           control={
-            <Checkbox
+            <CustomColorCheckbox 
               checked={option.checked}
               indeterminate={option.indeterminate}
-              onChange={(e) => handleCheckboxChange(option, e.target.checked)}
+              onChange={(e) => handleCheckboxChange(option, e.target.checked)} 
             />
           }
         />

--- a/carceral-groups-website/src/components/MaterialUI/FilterOptions.tsx
+++ b/carceral-groups-website/src/components/MaterialUI/FilterOptions.tsx
@@ -23,13 +23,13 @@ type filterOptionModel = {
   checked: boolean,
   indeterminate: boolean,
   geographicLocationFilter?: GeographicLocationFilter,
-  color: string
+  color?: string
 }
 
 const transformFiltersToFilterOptions = (filters: FiltersResponseFilter[]): filterOptionModel[] => {
   // add all option
   const newFilterOptions: filterOptionModel[] = []
-  const defaultOption: filterOptionModel = { prefix: '', label: 'All', level: 0, checked: true, indeterminate: false, color: '#f03' }
+  const defaultOption: filterOptionModel = { prefix: '', label: 'All', level: 0, checked: true, indeterminate: false}
   newFilterOptions.push(defaultOption)
 
   // add categories and institutions
@@ -44,14 +44,14 @@ const transformFiltersToFilterOptions = (filters: FiltersResponseFilter[]): filt
           level: 4,
           checked: true,
           indeterminate: false,
-          color: filter.color ? filter.color : '#f03',
+          color: filter.color,
           geographicLocationFilter: { Category: filter.category, Institution: curInstitution.institution, CategoryId: filter.categoryId, InstitutionId: curInstitution.institutionId }
         }
       })
       institionOptions.push(...possibleInstitutions)
     }
 
-    return { category: { prefix: ':All', label: filter.category, level: 2, checked: true, indeterminate: false, color: filter.color ? filter.color : '#f03' }, institutions: institionOptions }
+    return { category: { prefix: ':All', label: filter.category, level: 2, checked: true, indeterminate: false, color: filter.color }, institutions: institionOptions }
   })
 
 
@@ -151,6 +151,7 @@ export default function FilterOptions({ options, onOptionsChange }: FilterOption
               checked={option.checked}
               indeterminate={option.indeterminate}
               onChange={(e) => handleCheckboxChange(option, e.target.checked)} 
+              customColor={option.color}
             />
           }
         />

--- a/carceral-groups-website/src/hooks/useLeafletMap.ts
+++ b/carceral-groups-website/src/hooks/useLeafletMap.ts
@@ -71,6 +71,7 @@ const useLeafletMap = () => {
               popupContent: location.geographicLocationName,
               show_on_map: true,
               geographicLocationId: location.geographicLocationId,
+              color: location.color || '#0f00ff',
             },
           }
         })

--- a/carceral-groups-website/src/hooks/useLeafletMap.ts
+++ b/carceral-groups-website/src/hooks/useLeafletMap.ts
@@ -71,7 +71,7 @@ const useLeafletMap = () => {
               popupContent: location.geographicLocationName,
               show_on_map: true,
               geographicLocationId: location.geographicLocationId,
-              color: location.color || '#0f00ff',
+              color: location.color || '#f03',
             },
           }
         })

--- a/carceral-groups-website/src/models/FiltersResponseFilter.ts
+++ b/carceral-groups-website/src/models/FiltersResponseFilter.ts
@@ -1,7 +1,9 @@
+// represents one category that has institutions
 type FiltersResponseFilter = {
     categoryId: string
     category: string,
     institutions?: {institutionId: string, institution: string}[],
+    color?: string
 }
 
 export default FiltersResponseFilter

--- a/carceral-groups-website/src/models/GeographicLocation.ts
+++ b/carceral-groups-website/src/models/GeographicLocation.ts
@@ -4,18 +4,21 @@ export const DUMMY_GEO_LOCS: GeographicLocation[] = [
         latitude: "47.299723843258185",
         longitude: "-123.17403244585927",
         geographicLocationName: "Washington Corrections Center",
+        color: "#f03",
     },
     {
         geographicLocationId: 2,
         latitude: "46.73098767622705",
         longitude: "-117.16580759999998",
         geographicLocationName: "Evergreen Newsroom, Murrow Center",
+        color: "#f03",
     },
     {
         geographicLocationId: 3,
         latitude: "46.345958963317436",
         longitude: "-120.19008248921602",
         geographicLocationName: "La Escuelita, Granger, WA",
+        color: "#f03",
     }
 ]
 
@@ -26,6 +29,7 @@ type GeographicLocation = {
     geographicLocationName: string
     latitude: string
     longitude: string
+    color: string
 }
 
 export default GeographicLocation;

--- a/carceral-groups-website/src/models/GeographicLocationFilter.ts
+++ b/carceral-groups-website/src/models/GeographicLocationFilter.ts
@@ -1,4 +1,5 @@
 
+// represents one selected institution.
 type GeographicLocationFilter = {
     Category: string,
     Institution: string,


### PR DESCRIPTION
Adding color markers to filters and map markers

closes #44
closes #70 

Example:
**NOTE:** This example is not showing markers matching colors in filters yet. Markers will match the filter category they are being selected from. Using random colors to showcase flexibility of markers.
![image](https://github.com/DrewAGamboa/Carceral-Groups-Website/assets/16531155/cd3cfb2e-6ad5-4f83-b865-852079346982)
