### PR TITLE
124: Category Color API

### DIFF
--- a/carceral-groups-api/Controllers/CategoryController.cs
+++ b/carceral-groups-api/Controllers/CategoryController.cs
@@ -80,7 +80,7 @@ namespace carceral_groups_api.Controllers
                 if(category == null)
                     return NotFound();
 
-                var categoryExists = _dbContext.Categories.Any(m => m.Name == request.Name);
+                var categoryExists = _dbContext.Categories.Any(m => m.Name == request.Name && m.CategoryId != id);
                 if(categoryExists)
                     return StatusCode((int)HttpStatusCode.Conflict, Messages.ResourceAlreadyExists);
             }

--- a/carceral-groups-api/Controllers/CategoryController.cs
+++ b/carceral-groups-api/Controllers/CategoryController.cs
@@ -43,10 +43,10 @@ namespace carceral_groups_api.Controllers
         }
 
         [HttpPost]
-        public async Task<IActionResult?> Post([FromBody]string name)
+        public async Task<IActionResult?> Post([FromBody]CategoryCRUDModel request)
         {
             try{
-                var categoryExists = _dbContext.Categories.Any(m => m.Name == name);
+                var categoryExists = _dbContext.Categories.Any(m => m.Name == request.Name);
                 if(categoryExists)
                     return StatusCode((int)HttpStatusCode.Conflict, Messages.ResourceAlreadyExists);
             }
@@ -56,7 +56,8 @@ namespace carceral_groups_api.Controllers
 
             try{
                 var category = new Category{
-                    Name = name
+                    Name = request.Name,
+                    Color = request.Color
                 };
 
                 await _dbContext.Categories.AddAsync(category);
@@ -70,7 +71,7 @@ namespace carceral_groups_api.Controllers
         }
 
         [HttpPut("{id}")]
-        public async Task<IActionResult> Put(int id, [FromBody] string name)
+        public async Task<IActionResult> Put(int id, [FromBody] CategoryCRUDModel request)
         {
             Category? category = null;
 
@@ -79,7 +80,7 @@ namespace carceral_groups_api.Controllers
                 if(category == null)
                     return NotFound();
 
-                var categoryExists = _dbContext.Categories.Any(m => m.Name == name);
+                var categoryExists = _dbContext.Categories.Any(m => m.Name == request.Name);
                 if(categoryExists)
                     return StatusCode((int)HttpStatusCode.Conflict, Messages.ResourceAlreadyExists);
             }
@@ -88,7 +89,8 @@ namespace carceral_groups_api.Controllers
             }
 
             try{
-                category.Name = name;
+                category.Name = request.Name;
+                category.Color = request.Color;
 
                 _dbContext.Categories.Update(category);
                 await _dbContext.SaveChangesAsync();

--- a/carceral-groups-api/Controllers/DocumentController.cs
+++ b/carceral-groups-api/Controllers/DocumentController.cs
@@ -75,7 +75,7 @@ namespace carceral_groups_api.Controllers
                     GeographicLocationId = request.GeographicLocationId
                 };
 
-                // increment location stat
+                // increment location stat. TODO: refactor this into a method
                 var locationStat = await _dbContext.LocationDocumentStats.FirstOrDefaultAsync(m => m.GeographicLocationId == request.GeographicLocationId && m.CategoryId == request.CategoryId && m.InstitutionId == request.InstitutionId);
                 if (locationStat == null)
                 {
@@ -129,7 +129,7 @@ namespace carceral_groups_api.Controllers
             using var transaction = await _dbContext.Database.BeginTransactionAsync();
 
             try{
-                // decrement previous location stat
+                // decrement previous location stat. TODO: refactor this into a method
                 var oldLocationStat = await _dbContext.LocationDocumentStats.FirstOrDefaultAsync(m => m.GeographicLocationId == document.GeographicLocationId && m.CategoryId == document.CategoryId && m.InstitutionId == document.InstitutionId);
                 if (oldLocationStat != null)
                 {
@@ -154,7 +154,7 @@ namespace carceral_groups_api.Controllers
                 document.InstitutionId = request.InstitutionId;
                 document.GeographicLocationId = request.GeographicLocationId;
 
-                // increment location stat
+                // increment location stat. TODO: refactor this into a method
                 var locationStat = await _dbContext.LocationDocumentStats.FirstOrDefaultAsync(m => m.GeographicLocationId == request.GeographicLocationId && m.CategoryId == request.CategoryId && m.InstitutionId == request.InstitutionId);
                 if (locationStat == null)
                 {
@@ -203,7 +203,7 @@ namespace carceral_groups_api.Controllers
             using var transaction = await _dbContext.Database.BeginTransactionAsync();
 
             try{
-                // decrement previous location stat
+                // decrement previous location stat. TODO: refactor this into a method
                 var locationStat = await _dbContext.LocationDocumentStats.FirstOrDefaultAsync(m => m.GeographicLocationId == document.GeographicLocationId && m.CategoryId == document.CategoryId && m.InstitutionId == document.InstitutionId);
                 if (locationStat != null)
                 {

--- a/carceral-groups-api/Controllers/GeographicLocationsController.cs
+++ b/carceral-groups-api/Controllers/GeographicLocationsController.cs
@@ -29,9 +29,11 @@ namespace carceral_groups_api.Controllers
             var result = await query
                 .Where(predicate)
                 .Where(m => m.DocumentCount > 0)
-                .Select(m => new GeographicLocationCRUDModel(m.GeographicLocation, m.Category))
+                .Select(m => new GeographicLocationCRUDModel(m.GeographicLocation, m.Category, m.DocumentCount))
                 .ToListAsync();
-            // TODO: only return the highest count locations
+            result = result.GroupBy(m => m.GeographicLocationId)
+                .Select(m => m.OrderByDescending(n => n.DocumentCount).FirstOrDefault())
+                .ToList();
             return result;
         }
     }

--- a/carceral-groups-api/Controllers/GeographicLocationsController.cs
+++ b/carceral-groups-api/Controllers/GeographicLocationsController.cs
@@ -26,14 +26,23 @@ namespace carceral_groups_api.Controllers
                 predicate = predicate.Or(m => m.CategoryId == item.CategoryId && m.InstitutionId == item.InstitutionId);
             }
 
+            // Use a separate LocationDocumentStats table to store the document count for each location. 
+            // This is to avoid having to calculate the document count for each location every time a request is made.
+            // The application is more read-heavy than write-heavy, so this is a good trade-off.
+            // Github issue: https://github.com/DrewAGamboa/Carceral-Groups-Website/issues/124
             var result = await query
                 .Where(predicate)
                 .Where(m => m.DocumentCount > 0)
                 .Select(m => new GeographicLocationCRUDModel(m.GeographicLocation, m.Category, m.DocumentCount))
                 .ToListAsync();
+
+            // Group by GeographicLocationId and select the location with the highest document count.
+            // This is to avoid having multiple entries for the same location.
+            // Display the color of the location with the highest document count.
             result = result.GroupBy(m => m.GeographicLocationId)
                 .Select(m => m.OrderByDescending(n => n.DocumentCount).FirstOrDefault())
                 .ToList();
+                
             return result;
         }
     }

--- a/carceral-groups-api/EF/AppDbContext.cs
+++ b/carceral-groups-api/EF/AppDbContext.cs
@@ -13,7 +13,15 @@ namespace CarceralGroupsAPI
         public DbSet<Institution> Institutions { get; set; }
         public DbSet<LocationDocumentStat> LocationDocumentStats { get; set; }
 
-        public AppDbContext() {}
+        public AppDbContext() { }
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            base.OnModelCreating(modelBuilder);
+
+            modelBuilder.Entity<LocationDocumentStat>()
+                .HasKey(m => new { m.CategoryId, m.InstitutionId, m.GeographicLocationId });
+        }
 
         protected override void OnConfiguring(DbContextOptionsBuilder options) =>
         options.UseSqlServer(@"Server=tcp:carceral-webmap-mssql.database.windows.net,1433;Initial Catalog=carceral-webmap-db;Encrypt=True;TrustServerCertificate=False;Connection Timeout=30;Authentication=""Active Directory Default"";");

--- a/carceral-groups-api/EF/AppDbContext.cs
+++ b/carceral-groups-api/EF/AppDbContext.cs
@@ -11,6 +11,7 @@ namespace CarceralGroupsAPI
         public DbSet<FileType> FileTypes { get; set; }
         public DbSet<GeographicLocation> GeographicLocations { get; set; }
         public DbSet<Institution> Institutions { get; set; }
+        public DbSet<LocationDocumentStat> LocationDocumentStats { get; set; }
 
         public AppDbContext() {}
 

--- a/carceral-groups-api/EF/Models/Category.cs
+++ b/carceral-groups-api/EF/Models/Category.cs
@@ -8,5 +8,8 @@ namespace CarceralGroupsAPI
 
         [StringLength(maximumLength: 256)]
         public required string Name { get; set; }
+
+        [StringLength(maximumLength: 256)]
+        public string? Color { get; set; }
     }
 }

--- a/carceral-groups-api/EF/Models/LocationDocumentStat.cs
+++ b/carceral-groups-api/EF/Models/LocationDocumentStat.cs
@@ -1,18 +1,49 @@
 namespace CarceralGroupsAPI
 {
+    /// <summary>
+    /// Represents a statistical record of document counts for a specific geographic location, category, and institution.
+    /// The Primary key is a composite key of CategoryId, InstitutionId, and GeographicLocationId.
+    /// </summary>
     public class LocationDocumentStat
     {
+        /// <summary>
+        /// Gets or sets the ID of the category associated with the document count.
+        /// </summary>
         public required int CategoryId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the category associated with the document count.
+        /// </summary>
         public Category? Category { get; set; }
-        
+
+        /// <summary>
+        /// Gets or sets the ID of the institution associated with the document count.
+        /// </summary>
         public required int InstitutionId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the institution associated with the document count.
+        /// </summary>
         public Institution? Institution { get; set; }
 
+        /// <summary>
+        /// Gets or sets the ID of the geographic location associated with the document count.
+        /// </summary>
         public required int GeographicLocationId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the geographic location associated with the document count.
+        /// </summary>
         public GeographicLocation? GeographicLocation { get; set; }
 
+        /// <summary>
+        /// Gets or sets the count of documents for the specific geographic location, category, and institution.
+        /// </summary>
         public required int DocumentCount { get; set; }
 
+        /// <summary>
+        /// Gets or sets the date and time when the document count was last updated.
+        /// </summary>
         public DateTime LastUpdated { get; set; }
     }
 }

--- a/carceral-groups-api/EF/Models/LocationDocumentStat.cs
+++ b/carceral-groups-api/EF/Models/LocationDocumentStat.cs
@@ -1,0 +1,20 @@
+namespace CarceralGroupsAPI
+{
+    public class LocationDocumentStat
+    {
+        public required int LocationDocumentStatId { get; set; }
+
+        public required int CategoryId { get; set; }
+        public Category? Category { get; set; }
+        
+        public required int InstitutionId { get; set; }
+        public Institution? Institution { get; set; }
+
+        public required int GeographicLocationId { get; set; }
+        public GeographicLocation? GeographicLocation { get; set; }
+
+        public required int DocumentCount { get; set; }
+
+        public DateTime LastUpdated { get; set; }
+    }
+}

--- a/carceral-groups-api/EF/Models/LocationDocumentStat.cs
+++ b/carceral-groups-api/EF/Models/LocationDocumentStat.cs
@@ -2,8 +2,6 @@ namespace CarceralGroupsAPI
 {
     public class LocationDocumentStat
     {
-        public required int LocationDocumentStatId { get; set; }
-
         public required int CategoryId { get; set; }
         public Category? Category { get; set; }
         

--- a/carceral-groups-api/Migrations/20240630162813_AddColorToCategory.Designer.cs
+++ b/carceral-groups-api/Migrations/20240630162813_AddColorToCategory.Designer.cs
@@ -3,6 +3,7 @@ using CarceralGroupsAPI;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -10,9 +11,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace carceral_groups_api.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20240630162813_AddColorToCategory")]
+    partial class AddColorToCategory
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/carceral-groups-api/Migrations/20240630162813_AddColorToCategory.cs
+++ b/carceral-groups-api/Migrations/20240630162813_AddColorToCategory.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace carceral_groups_api.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddColorToCategory : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "Color",
+                table: "Categories",
+                type: "nvarchar(256)",
+                maxLength: 256,
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "Color",
+                table: "Categories");
+        }
+    }
+}

--- a/carceral-groups-api/Migrations/20240630174207_AddLocationDocumentStats.Designer.cs
+++ b/carceral-groups-api/Migrations/20240630174207_AddLocationDocumentStats.Designer.cs
@@ -4,6 +4,7 @@ using CarceralGroupsAPI;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace carceral_groups_api.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20240630174207_AddLocationDocumentStats")]
+    partial class AddLocationDocumentStats
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/carceral-groups-api/Migrations/20240630174207_AddLocationDocumentStats.cs
+++ b/carceral-groups-api/Migrations/20240630174207_AddLocationDocumentStats.cs
@@ -1,0 +1,72 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace carceral_groups_api.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddLocationDocumentStats : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "LocationDocumentStats",
+                columns: table => new
+                {
+                    LocationDocumentStatId = table.Column<int>(type: "int", nullable: false)
+                        .Annotation("SqlServer:Identity", "1, 1"),
+                    CategoryId = table.Column<int>(type: "int", nullable: false),
+                    InstitutionId = table.Column<int>(type: "int", nullable: false),
+                    GeographicLocationId = table.Column<int>(type: "int", nullable: false),
+                    DocumentCount = table.Column<int>(type: "int", nullable: false),
+                    LastUpdated = table.Column<DateTime>(type: "datetime2", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_LocationDocumentStats", x => x.LocationDocumentStatId);
+                    table.ForeignKey(
+                        name: "FK_LocationDocumentStats_Categories_CategoryId",
+                        column: x => x.CategoryId,
+                        principalTable: "Categories",
+                        principalColumn: "CategoryId",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_LocationDocumentStats_GeographicLocations_GeographicLocationId",
+                        column: x => x.GeographicLocationId,
+                        principalTable: "GeographicLocations",
+                        principalColumn: "GeographicLocationId",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_LocationDocumentStats_Institutions_InstitutionId",
+                        column: x => x.InstitutionId,
+                        principalTable: "Institutions",
+                        principalColumn: "InstitutionId",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_LocationDocumentStats_CategoryId",
+                table: "LocationDocumentStats",
+                column: "CategoryId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_LocationDocumentStats_GeographicLocationId",
+                table: "LocationDocumentStats",
+                column: "GeographicLocationId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_LocationDocumentStats_InstitutionId",
+                table: "LocationDocumentStats",
+                column: "InstitutionId");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "LocationDocumentStats");
+        }
+    }
+}

--- a/carceral-groups-api/Migrations/20240630185029_AddLocationDocumentStats.Designer.cs
+++ b/carceral-groups-api/Migrations/20240630185029_AddLocationDocumentStats.Designer.cs
@@ -12,7 +12,7 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace carceral_groups_api.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    [Migration("20240630174207_AddLocationDocumentStats")]
+    [Migration("20240630185029_AddLocationDocumentStats")]
     partial class AddLocationDocumentStats
     {
         /// <inheritdoc />
@@ -224,30 +224,22 @@ namespace carceral_groups_api.Migrations
 
             modelBuilder.Entity("CarceralGroupsAPI.LocationDocumentStat", b =>
                 {
-                    b.Property<int>("LocationDocumentStatId")
-                        .ValueGeneratedOnAdd()
-                        .HasColumnType("int");
-
-                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("LocationDocumentStatId"));
-
                     b.Property<int>("CategoryId")
-                        .HasColumnType("int");
-
-                    b.Property<int>("DocumentCount")
-                        .HasColumnType("int");
-
-                    b.Property<int>("GeographicLocationId")
                         .HasColumnType("int");
 
                     b.Property<int>("InstitutionId")
                         .HasColumnType("int");
 
+                    b.Property<int>("GeographicLocationId")
+                        .HasColumnType("int");
+
+                    b.Property<int>("DocumentCount")
+                        .HasColumnType("int");
+
                     b.Property<DateTime>("LastUpdated")
                         .HasColumnType("datetime2");
 
-                    b.HasKey("LocationDocumentStatId");
-
-                    b.HasIndex("CategoryId");
+                    b.HasKey("CategoryId", "InstitutionId", "GeographicLocationId");
 
                     b.HasIndex("GeographicLocationId");
 

--- a/carceral-groups-api/Migrations/20240630185029_AddLocationDocumentStats.cs
+++ b/carceral-groups-api/Migrations/20240630185029_AddLocationDocumentStats.cs
@@ -15,8 +15,6 @@ namespace carceral_groups_api.Migrations
                 name: "LocationDocumentStats",
                 columns: table => new
                 {
-                    LocationDocumentStatId = table.Column<int>(type: "int", nullable: false)
-                        .Annotation("SqlServer:Identity", "1, 1"),
                     CategoryId = table.Column<int>(type: "int", nullable: false),
                     InstitutionId = table.Column<int>(type: "int", nullable: false),
                     GeographicLocationId = table.Column<int>(type: "int", nullable: false),
@@ -25,7 +23,7 @@ namespace carceral_groups_api.Migrations
                 },
                 constraints: table =>
                 {
-                    table.PrimaryKey("PK_LocationDocumentStats", x => x.LocationDocumentStatId);
+                    table.PrimaryKey("PK_LocationDocumentStats", x => new { x.CategoryId, x.InstitutionId, x.GeographicLocationId });
                     table.ForeignKey(
                         name: "FK_LocationDocumentStats_Categories_CategoryId",
                         column: x => x.CategoryId,
@@ -45,11 +43,6 @@ namespace carceral_groups_api.Migrations
                         principalColumn: "InstitutionId",
                         onDelete: ReferentialAction.Cascade);
                 });
-
-            migrationBuilder.CreateIndex(
-                name: "IX_LocationDocumentStats_CategoryId",
-                table: "LocationDocumentStats",
-                column: "CategoryId");
 
             migrationBuilder.CreateIndex(
                 name: "IX_LocationDocumentStats_GeographicLocationId",

--- a/carceral-groups-api/Migrations/AppDbContextModelSnapshot.cs
+++ b/carceral-groups-api/Migrations/AppDbContextModelSnapshot.cs
@@ -221,30 +221,22 @@ namespace carceral_groups_api.Migrations
 
             modelBuilder.Entity("CarceralGroupsAPI.LocationDocumentStat", b =>
                 {
-                    b.Property<int>("LocationDocumentStatId")
-                        .ValueGeneratedOnAdd()
-                        .HasColumnType("int");
-
-                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("LocationDocumentStatId"));
-
                     b.Property<int>("CategoryId")
-                        .HasColumnType("int");
-
-                    b.Property<int>("DocumentCount")
-                        .HasColumnType("int");
-
-                    b.Property<int>("GeographicLocationId")
                         .HasColumnType("int");
 
                     b.Property<int>("InstitutionId")
                         .HasColumnType("int");
 
+                    b.Property<int>("GeographicLocationId")
+                        .HasColumnType("int");
+
+                    b.Property<int>("DocumentCount")
+                        .HasColumnType("int");
+
                     b.Property<DateTime>("LastUpdated")
                         .HasColumnType("datetime2");
 
-                    b.HasKey("LocationDocumentStatId");
-
-                    b.HasIndex("CategoryId");
+                    b.HasKey("CategoryId", "InstitutionId", "GeographicLocationId");
 
                     b.HasIndex("GeographicLocationId");
 

--- a/carceral-groups-api/Models/CategoryCRUDModel.cs
+++ b/carceral-groups-api/Models/CategoryCRUDModel.cs
@@ -1,0 +1,26 @@
+using System.ComponentModel.DataAnnotations;
+using System.Diagnostics.CodeAnalysis;
+
+namespace CarceralGroupsAPI
+{
+    public class CategoryCRUDModel
+    {
+        public CategoryCRUDModel(){}
+
+        [SetsRequiredMembers]
+        public CategoryCRUDModel(Category category)
+        {
+            CategoryId = category.CategoryId;
+            Name = category.Name;
+            Color = category.Color;
+        }
+
+        public int CategoryId { get; set; }
+
+        [StringLength(maximumLength: 256)]
+        public required string Name { get; set; }
+
+        [StringLength(maximumLength: 256)]
+        public string? Color { get; set; }
+    }
+}

--- a/carceral-groups-api/Models/GeographicLocationCRUDModel.cs
+++ b/carceral-groups-api/Models/GeographicLocationCRUDModel.cs
@@ -17,13 +17,14 @@ namespace CarceralGroupsAPI
         }
 
         [SetsRequiredMembers]
-        public GeographicLocationCRUDModel(GeographicLocation geographicLocation, Category category)
+        public GeographicLocationCRUDModel(GeographicLocation geographicLocation, Category category, int documentCount)
         {
             GeographicLocationId = geographicLocation.GeographicLocationId;
             GeographicLocationName = geographicLocation.GeographicLocationName;
             Latitude = geographicLocation.Latitude;
             Longitude = geographicLocation.Longitude;
             Color = category?.Color;
+            DocumentCount = documentCount;
         }
 
         public int GeographicLocationId { get; set; }
@@ -37,6 +38,7 @@ namespace CarceralGroupsAPI
         [StringLength(maximumLength: 32)]
         public required string Longitude { get; set; }
 
+        public int DocumentCount { get; set; }
         public string? Color { get; set; }
     }
 }

--- a/carceral-groups-api/Models/GeographicLocationCRUDModel.cs
+++ b/carceral-groups-api/Models/GeographicLocationCRUDModel.cs
@@ -16,6 +16,16 @@ namespace CarceralGroupsAPI
             Longitude = geographicLocation.Longitude;
         }
 
+        [SetsRequiredMembers]
+        public GeographicLocationCRUDModel(GeographicLocation geographicLocation, Category category)
+        {
+            GeographicLocationId = geographicLocation.GeographicLocationId;
+            GeographicLocationName = geographicLocation.GeographicLocationName;
+            Latitude = geographicLocation.Latitude;
+            Longitude = geographicLocation.Longitude;
+            Color = category?.Color;
+        }
+
         public int GeographicLocationId { get; set; }
         
         [StringLength(maximumLength: 256)]
@@ -26,5 +36,7 @@ namespace CarceralGroupsAPI
 
         [StringLength(maximumLength: 32)]
         public required string Longitude { get; set; }
+
+        public string? Color { get; set; }
     }
 }

--- a/carceral-groups-api/SQL/CalculateLocationDocumentStats.sql
+++ b/carceral-groups-api/SQL/CalculateLocationDocumentStats.sql
@@ -1,0 +1,21 @@
+BEGIN TRANSACTION;
+
+-- Step 1: Clear the LocationStat table
+TRUNCATE TABLE LocationDocumentStats;
+
+-- Step 2: Insert new records with the current date and time
+INSERT INTO LocationDocumentStats (CategoryId, InstitutionId, GeographicLocationId, DocumentCount, LastUpdated)
+SELECT 
+    CategoryId, 
+    InstitutionId, 
+    GeographicLocationId, 
+    COUNT(DocumentId) AS DocumentCount,
+    GETUTCDATE() AS LastUpdated
+FROM 
+    [dbo].[Documents]
+GROUP BY 
+    CategoryId, 
+    InstitutionId, 
+    GeographicLocationId;
+
+COMMIT TRANSACTION;

--- a/carceral-groups-api/SQL/CalculateLocationDocumentStats.sql
+++ b/carceral-groups-api/SQL/CalculateLocationDocumentStats.sql
@@ -1,3 +1,6 @@
+-- Summary: This script calculates the number of documents for each location and category and inserts the results into the LocationDocumentStats table.
+-- The script is intended to run to calculate all the statistics for all current documents in the database.
+
 BEGIN TRANSACTION;
 
 -- Step 1: Clear the LocationStat table

--- a/carceral-groups-website/package-lock.json
+++ b/carceral-groups-website/package-lock.json
@@ -21,6 +21,7 @@
         "axios": "^1.6.8",
         "leaflet": "^1.9.4",
         "localforage": "^1.10.0",
+        "mui-color-input": "^2.0.3",
         "papaparse": "^5.4.1",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
@@ -729,6 +730,14 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@ctrl/tinycolor": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@ctrl/tinycolor/-/tinycolor-4.1.0.tgz",
+      "integrity": "sha512-WyOx8cJQ+FQus4Mm4uPIZA64gbk3Wxh0so5Lcii0aJifqwoVOlfFtorjLE0Hen4OYyHZMXDWqMmaQemBhgxFRQ==",
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/@emotion/babel-plugin": {
@@ -3893,6 +3902,27 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+    },
+    "node_modules/mui-color-input": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/mui-color-input/-/mui-color-input-2.0.3.tgz",
+      "integrity": "sha512-rAd040qQ0Y+8dk4gE8kkCiJ/vCgA0j4vv1quJ43BfORTFE3uHarHj0xY1Vo9CPbojtx1f5vW+CjckYPRIZPIRg==",
+      "dependencies": {
+        "@ctrl/tinycolor": "^4.0.3"
+      },
+      "peerDependencies": {
+        "@emotion/react": "^11.5.0",
+        "@emotion/styled": "^11.3.0",
+        "@mui/material": "^5.0.0",
+        "@types/react": "^18.0.0",
+        "react": "^18.0.0",
+        "react-dom": "^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
     },
     "node_modules/nanoid": {
       "version": "3.3.7",

--- a/carceral-groups-website/package.json
+++ b/carceral-groups-website/package.json
@@ -23,6 +23,7 @@
     "axios": "^1.6.8",
     "leaflet": "^1.9.4",
     "localforage": "^1.10.0",
+    "mui-color-input": "^2.0.3",
     "papaparse": "^5.4.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/carceral-groups-website/src/api/services/GeographicCategoryService.ts
+++ b/carceral-groups-website/src/api/services/GeographicCategoryService.ts
@@ -6,12 +6,13 @@ const backend_api_url = import.meta.env.VITE_BACKEND_API_URL
 
 export async function createGeographicCategory() {
     try {
+        const name = `New Category ${Date.now()}`
         const response = await fetch(`${backend_api_url}/Category`, {
             method: 'POST',
             headers: {
                 'Content-Type': 'application/json'
             },
-            body: JSON.stringify(`New Category ${Date.now()}`) // TODO: Revisit this if category name is not the only field
+            body: JSON.stringify({name})
         
         })
         const resJson = await response.json()
@@ -54,12 +55,13 @@ export async function getGeographicCategory(id: string) {
 
 export async function updateGeographicCategory(id: string, updates: any) {
     try{
+        const updatedCategory = { ...updates, color: updates.color?.length > 0 ? updates.color : undefined}
         const response = await fetch(`${backend_api_url}/Category/${id}`, {
             method: 'PUT',
             headers: {
                 'Content-Type': 'application/json'
             },
-            body: JSON.stringify(updates.name) // TODO: Revisit this if category name is not the only field
+            body: JSON.stringify(updatedCategory)
         })
         const resJson = await response.json()
         const updatedGeographicCategory = resJson as GeographicCategory

--- a/carceral-groups-website/src/components/CRUD/GeographicCategory/GeographicCategoryForm.tsx
+++ b/carceral-groups-website/src/components/CRUD/GeographicCategory/GeographicCategoryForm.tsx
@@ -13,22 +13,29 @@ const GeographicCategoryForm = (props: GeographicCategoryFormProps) => {
     const { geographicCategory, children, isEdit } = props;
 
     const [inputName, setInputName] = useState<string>(geographicCategory.name || '');
+    const [inputColor, setInputColor] = useState<string>(geographicCategory.color || '');
 
     const handleNameChange = (event: React.ChangeEvent<HTMLInputElement>) => {
         setInputName(event.target.value);
     }
 
+    const handleColorChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+        setInputColor(event.target.value);
+    }
+
     const textProps = isEdit ? { required: true } : { disabled: true };
+    const notRequiredTextProps = isEdit ? {} : { disabled: true };
 
     useEffect(() => {
         setInputName(geographicCategory.name);
+        setInputColor(geographicCategory.color || '');
     }, [geographicCategory])
 
     return (
         <Box
             component="section"
             sx={{
-                '& .MuiTextField-root': { m: 1, width: '25ch' },
+                '& .MuiTextField-root': { m: 1 },
                 p: 2,
                 m: 2,
             }}>
@@ -42,6 +49,7 @@ const GeographicCategoryForm = (props: GeographicCategoryFormProps) => {
                 Details
             </Typography>
             <TextField
+                fullWidth
                 margin="dense"
                 id="name"
                 name="name"
@@ -50,6 +58,17 @@ const GeographicCategoryForm = (props: GeographicCategoryFormProps) => {
                 value={inputName}
                 onChange={handleNameChange}
                 {...textProps}
+            />
+            <TextField
+                fullWidth
+                margin="dense"
+                id="color"
+                name="color"
+                label="Category Color"
+                type="text"
+                value={inputColor}
+                onChange={handleColorChange}
+                {...notRequiredTextProps}
             />
             <Box
                 display="flex"

--- a/carceral-groups-website/src/components/CRUD/GeographicCategory/GeographicCategoryForm.tsx
+++ b/carceral-groups-website/src/components/CRUD/GeographicCategory/GeographicCategoryForm.tsx
@@ -1,7 +1,7 @@
 import { Box, TextField, Typography } from "@mui/material";
 import GeographicCategory from "../../../models/GeographicCategory";
 import { useEffect, useState } from "react";
-
+import { MuiColorInput } from 'mui-color-input'
 
 type GeographicCategoryFormProps = {
     geographicCategory: GeographicCategory
@@ -19,8 +19,8 @@ const GeographicCategoryForm = (props: GeographicCategoryFormProps) => {
         setInputName(event.target.value);
     }
 
-    const handleColorChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-        setInputColor(event.target.value);
+    const handleColorChange = (value: string) => {
+        setInputColor(value);
     }
 
     const textProps = isEdit ? { required: true } : { disabled: true };
@@ -59,15 +59,15 @@ const GeographicCategoryForm = (props: GeographicCategoryFormProps) => {
                 onChange={handleNameChange}
                 {...textProps}
             />
-            <TextField
+            <MuiColorInput
                 fullWidth
                 margin="dense"
                 id="color"
                 name="color"
-                label="Category Color"
-                type="text"
+                format="hex"
                 value={inputColor}
                 onChange={handleColorChange}
+                label="Category Color"
                 {...notRequiredTextProps}
             />
             <Box

--- a/carceral-groups-website/src/components/CRUD/GeographicCategory/GeographicCategorys.tsx
+++ b/carceral-groups-website/src/components/CRUD/GeographicCategory/GeographicCategorys.tsx
@@ -27,7 +27,7 @@ export async function action() {
 
 const GeographicCategorys = () => {
     const { geographicCategorys } = useLoaderData() as { geographicCategorys: GeographicCategory[] };
-    const tableHeaderInfo = [{ name: "Id" }, { name: "Category Name" }]
+    const tableHeaderInfo = [{ name: "Id" }, { name: "Category Name" }, { name: "Color" }]
     const tableRows = geographicCategorys
     const navigate = useNavigate();
 

--- a/carceral-groups-website/src/models/GeographicCategory.ts
+++ b/carceral-groups-website/src/models/GeographicCategory.ts
@@ -21,7 +21,8 @@ export const primaryKeyName = "categoryId"; // used in BasicTable.tsx
 
 type GeographicCategory = {
     categoryId: number,
-    name: string
+    name: string,
+    color?: string
 }
 
 export default GeographicCategory;


### PR DESCRIPTION
closes #124 

**Manual steps needed once pull request is completed:**
1. Run `dotnet ef database update`
2. Run query located in `CalculateLocationDocumentStats.sql`

## Overview
Enables backend api and data model to have categories specify colors of locations on a map.

Added a LocationDocumentStats table to keep track of how many documents belong to a location on a map. This is to help avoid calculating all document counts filtered by category and institution each time we want to display locations on a map.

We can specify a color for a category now as well.
![image](https://github.com/DrewAGamboa/Carceral-Groups-Website/assets/16531155/7cd4cccf-1804-4bda-b023-bdb4e861dc45)